### PR TITLE
Update docker-image.yml

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,10 +1,9 @@
 name: Build and Publish Docker Image
 
 on:
-  workflow_dispatch:
-  #push:
-  #  branches:
-  #    - main
+  push:
+    branches:
+      - main
 
 jobs:
   build:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,9 +1,10 @@
 name: Build and Publish Docker Image
 
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
+  #push:
+  #  branches:
+  #    - main
 
 jobs:
   build:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -9,6 +9,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
## What changed

- Granted permissions to push docker images to github packages via permissions object injected into job.

## Explanation

- By default, GitHub workflows work with a GITHUB_TOKEN, which has pre-defined permissions; if we need to change those perms for a specific workflow, we need to update the permissions object. 