### PR TITLE
Lock runner version and add paths to build trigger

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -4,10 +4,14 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'app/**'
+      - 'requirements.txt'
+      - 'Dockerfile'
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     permissions:
       contents: read


### PR DESCRIPTION
## What changed

- We locked the build runner to use a specific ubuntu version
- We defined paths to build trigger

## Explanation

- Without locking the version, we're going to run the builds always with the latest runner which can be troublesome if at some time we start to depends on some deps from the runner instance.
- The build trigger has been defined to avoid building the image when we update k8s manifests or docs which would not change anything in the app itself